### PR TITLE
:+1: ヘッダーの前に日時を追加する

### DIFF
--- a/lib/lita/handlers/kintai.rb
+++ b/lib/lita/handlers/kintai.rb
@@ -51,7 +51,7 @@ Then tell me the code as follows: `code \#{your_code}`
 
       def kintai_info
         texts = ""
-        texts << config.template_header
+        texts << "#{Date.today.strftime("%m/%d")} (#{%w(日 月 火 水 木 金 土)[Date.today.wday]})#{config.template_header}"
 
         mails = find_mail(config.query)
         # query の `newer:#{Date.today.strftime("%Y/%m/%d")}` 昨日のも一部返ってくる


### PR DESCRIPTION
config の template に書いても、評価タイミングの問題で
起動した日のままになるので暫定対応
